### PR TITLE
Disable adding Deposit Transactions to Txpool

### DIFF
--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -791,6 +791,13 @@ func (p *TxPool) AddRemoteTxs(_ context.Context, newTxs types.TxSlots) {
 }
 
 func (p *TxPool) validateTx(txn *types.TxSlot, isLocal bool, stateCache kvcache.CacheView) DiscardReason {
+	// No unauthenticated deposits allowed in the transaction pool.
+	// This is for spam protection, not consensus,
+	// as the external engine-API user authenticates deposits.
+	if txn.Type == types.DepositTxType {
+		return TxTypeNotSupported
+	}
+
 	isShanghai := p.isShanghai()
 	if isShanghai {
 		if txn.DataLen > fixedgas.MaxInitCodeSize {

--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -142,6 +142,7 @@ const (
 	NotReplaced         DiscardReason = 20 // There was an existing transaction with the same sender and nonce, not enough price bump to replace
 	DuplicateHash       DiscardReason = 21 // There was an existing transaction with the same hash
 	InitCodeTooLarge    DiscardReason = 22 // EIP-3860 - transaction init code is too large
+	TxTypeNotSupported  DiscardReason = 23
 )
 
 func (r DiscardReason) String() string {
@@ -192,6 +193,8 @@ func (r DiscardReason) String() string {
 		return "existing tx with same hash"
 	case InitCodeTooLarge:
 		return "initcode too large"
+	case TxTypeNotSupported:
+		return types.ErrTxTypeNotSupported.Error()
 	default:
 		panic(fmt.Sprintf("discard reason: %d", r))
 	}

--- a/txpool/txpool_grpc_server.go
+++ b/txpool/txpool_grpc_server.go
@@ -238,7 +238,7 @@ func mapDiscardReasonToProto(reason DiscardReason) txpool_proto.ImportResult {
 		return txpool_proto.ImportResult_ALREADY_EXISTS
 	case UnderPriced, ReplaceUnderpriced, FeeTooLow:
 		return txpool_proto.ImportResult_FEE_TOO_LOW
-	case InvalidSender, NegativeValue, OversizedData, InitCodeTooLarge, RLPTooLong:
+	case InvalidSender, NegativeValue, OversizedData, InitCodeTooLarge, RLPTooLong, TxTypeNotSupported:
 		return txpool_proto.ImportResult_INVALID
 	default:
 		return txpool_proto.ImportResult_INTERNAL_ERROR

--- a/types/txn.go
+++ b/types/txn.go
@@ -115,6 +115,7 @@ var ErrParseTxn = fmt.Errorf("%w transaction", rlp.ErrParse)
 var ErrRejected = errors.New("rejected")
 var ErrAlreadyKnown = errors.New("already known")
 var ErrRlpTooBig = errors.New("txn rlp too big")
+var ErrTxTypeNotSupported = errors.New("transaction type not supported")
 
 func (ctx *TxParseContext) ValidateRLP(f func(txnRlp []byte) error) { ctx.validateRlp = f }
 func (ctx *TxParseContext) WithSender(v bool)                       { ctx.withSender = v }


### PR DESCRIPTION
## Specification

According to the [execution engine spec](https://github.com/ethereum-optimism/optimism/blob/develop/specs/exec-engine.md#deposited-transaction-boundaries):
> Deposited transactions MUST never be consumed from the transaction pool. The transaction pool can be disabled in a deposits-only rollup

Therefore we must ignore deposit transactions when
* exec engine received local deposit transactions when `eth_sendRawTransaction` RPC is called
* exec engine received remote deposit transactions using p2p tx pool gossiping. 

## Implementation

We can safely drop deposit transactions from above cases by patching `validateTx` method. If method receives deposit transactions, make it throw `TxTypeNotSupported` error. `validateTx` method is wrapped by `validateTxs` method.

There are three control flows which results in calling `validateTx` method before actually _promoting_ transactions. Here, the word _promote_ means adding transaction to actual queue of txpool(`TxPool.queued` SubPool).

1. Local TX: `pool.go::AddLocalTxs()` method handles local transactions received by RPC. It first calls `validateTxs` method to sanitize transactions and call `pool.go::addTxs()` to promote transactions.
2. Remote Tx: `pool.go::processRemoteTxs()` method handles remote transactions gossiped by p2p. It first calls `validateTx` method to sanitize transactions and call `pool.go::addTxs()` to promote transactions.
3. OnNewBlock: `pool.go::OnNewBlock()` method updates TxPool when new block is added. If new block is added, it must update TxPool by removing already mined transactions. If reorg occurred and unwind needed, reinsert transactions included at reorg blocks to the TxPool. It first calls `validateTxs` method to sanitize transactions and call `pool.go::addTxsOnNewBlock()` to promote transactions.

By patching `validateTx` method, we can explicitly drop deposit transactions in every case, never making deposit transactions enter a TxPool.

The error message `"transaction type not supported"` is consistent with op-geth's [`ErrTxTypeNotSupported`](https://github.com/ethereum-optimism/op-geth/blob/optimism/core/types/transaction.go#L39C9-L39C9) error message. Also, error message declaration of `ErrTxTypeNotSupported` was [already defined](https://github.com/testinprod-io/op-erigon/blob/df6024316025dec816a39f6e9fa090bfd4923ed2/core/types/transaction.go#L47) at erigon. This duplication is intended because erigon intentionally separated txpool implementation, at different repository erigon-lib.

After this PR is merged, will update op-erigon to apply erigon-lib changes.



